### PR TITLE
fix(really-io): properly encode accessTokens for WebSocketHandler tests

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,16 +9,13 @@ object Dependencies {
   val wsClient = "io.backchat.hookup" %% "hookup" % "0.2.3"
   val snakeyaml = "org.yaml" % "snakeyaml" % "1.14"
   val commonsIO= "commons-io" % "commons-io" % "2.4"
-
   val parserCombinator = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2"
-
   val reactivemongo = "org.reactivemongo" %% "reactivemongo" % "0.10.5.0.akka23"
   val embedmongo = "com.github.simplyscala" %% "scalatest-embedmongo" % "0.2.2" % "test"
   val slick = "com.typesafe.slick" %% "slick" % "2.1.0"
   val h2 = "com.h2database" % "h2" % "1.3.175"
-
   val playScalaTest = "org.scalatestplus" %% "play" % "1.2.0" % "test"
-  val jwtScala = "io.really" %% "jwt-scala" % "1.0"
+  val jwtScala = "io.really" %% "jwt-scala" % "1.1"
 
   object Akka {
     private val akkaBase = "com.typesafe.akka"
@@ -30,22 +27,8 @@ object Dependencies {
     val cluster = akkaBase %% "akka-cluster" % version
     val contrib = akkaBase %% "akka-contrib" % version
     val slf4j = akkaBase %%  "akka-slf4j"	%	version
-
     val persistance = akkaBase %% "akka-persistence-experimental" % version
-//    val cassandraPersistence = "com.github.krasserm" %% "akka-persistence-cassandra" % "0.3.3"
     val multiNode = akkaBase %% "akka-multi-node-testkit" % version
-//    val kafkaPersistence = "com.github.krasserm" %% "akka-persistence-kafka" % "0.3.2"
   }
-
-//  object Playframework {
-//    private val version = "2.3.6"
-//    private val playBase = "com.typesafe.play"
-//
-////    val json = playBase %% "play-json" % version
-////    val ws = playBase %% "play-ws" % version
-////    val cache = playBase %% "play-cache" % version
-////    val functional = playBase %% "play-functional" % version
-//
-//  }
 
 }

--- a/really-io/test/io/really/io/socket/WebSocketHandlerSpec.scala
+++ b/really-io/test/io/really/io/socket/WebSocketHandlerSpec.scala
@@ -4,6 +4,7 @@
 
 package io.really.io.socket
 
+import _root_.io.really.jwt._
 import io.really._
 import akka.actor.Props
 import akka.testkit.TestProbe
@@ -11,24 +12,19 @@ import play.api.libs.json._
 import play.api.test._
 import _root_.io.really.io.{ IOGlobals, IOConfig }
 
-import scala.util.parsing.json.JSONObject
-
 class WebSocketHandlerSpec extends BaseIOActorSpec {
-  //    println("************************START********************************")
-  //    println("************************STOP*********************************")
   val client = TestProbe()
   val clientRef = client.ref
+
+  val token = JWT.encode(config.io.accessTokenSecret, Json.obj(), Json.obj(), Some(Algorithm.HS256))
   val fakeRequest = new FakeRequest("POST", "http://www.really.io", new FakeHeaders(), """""".stripMargin)
 
   val valid_msg =
-    """{
-        "email": "reallyApp@really.io",
-        "r": "/users/123",
-        "Application":"reallyApp",
+    s"""{
         "tag": 123,
         "traceId" : "@trace123",
         "cmd":"initialize",
-        "accessToken":"Ac66bf"
+        "accessToken": "$token"
         }"""
 
   "Web Socket Handler" should "fail to initialize with incorrect msg format" in {
@@ -64,14 +60,12 @@ class WebSocketHandlerSpec extends BaseIOActorSpec {
       )
     )
     val invalid_initialize_msg =
-      """{
-        "email": "reallyApp@really.io",
+      s"""{
         "r": "/users/123",
-        "Application":"reallyApp",
         "tag": "testtag",
         "traceId" : "@trace123",
         "cmd":"initialize",
-        "accessToken":"Ac66bf"
+        "accessToken":"$token"
         }"""
     handler ! invalid_initialize_msg
     val em = client.expectMsgType[JsObject]
@@ -92,9 +86,6 @@ class WebSocketHandlerSpec extends BaseIOActorSpec {
     )
     val invalid_initialize_msg =
       """{
-        "email": "reallyApp@really.io",
-        "r": "/users/123",
-        "Application":"reallyApp",
         "tag": 123,
         "traceId" : "@trace123",
         "cmd":"GET",
@@ -119,9 +110,7 @@ class WebSocketHandlerSpec extends BaseIOActorSpec {
     )
     val invalid_initialize_msg =
       """{
-        "email": "reallyApp@really.io",
         "r": "/users/123",
-        "Application":"reallyApp",
         "tag": 123,
         "traceId" : "@trace123",
         "cmd":"initialize",
@@ -145,14 +134,11 @@ class WebSocketHandlerSpec extends BaseIOActorSpec {
       )
     )
     val valid_initialize_msg =
-      """{
-        "email": "reallyApp@really.io",
-        "r": "/users/123",
-        "Application":"reallyApp",
+      s"""{
         "tag": 123,
         "traceId" : "@trace123",
         "cmd":"initialize",
-        "accessToken":"eyJhbGciOiJIbWFjU0hBMjU2IiwidHlwIjoiSldUIn0.eyJuYW1lIjoiQWhtZWQiLCJlbWFpbCI6ImFobWVkQGdtYWlsLmNvbSJ9.77-977-977-9ZX1xee-_vQxJKu-_ve-_vQvvv70c77-9OO-_ve-_ve-_ve-_ve-_vQfvv71277-9fjhj77-9bw"
+        "accessToken":"$token"
         }"""
     handler ! valid_initialize_msg
     val em = client.expectMsgType[JsValue]


### PR DESCRIPTION
also upgrades scala-jwt to 1.1
