### PR TITLE
RIO-83 fix (really-core): SubscriptionManager fix

### DIFF
--- a/really-core/src/main/scala/io/really/gorilla/GorillaEventCenter.scala
+++ b/really-core/src/main/scala/io/really/gorilla/GorillaEventCenter.scala
@@ -45,7 +45,7 @@ class GorillaEventCenter(globals: ReallyGlobals)(implicit session: Session) exte
   }
 
   def handleSubscriptions: Receive = {
-    case NewSubscription(rSub) =>
+    case NewSubscription(replyTo, rSub) =>
       val objectSubscriber = context.actorOf(globals.objectSubscriberProps(rSub))
       val replayer = markers.filter(_.r === rSub.r).firstOption match {
         case Some((_, rev)) =>
@@ -55,7 +55,7 @@ class GorillaEventCenter(globals: ReallyGlobals)(implicit session: Session) exte
       }
       globals.mediator ! Subscribe(rSub.r.toString, replayer)
       objectSubscriber ! ReplayerSubscribed(replayer)
-      sender() ! ObjectSubscribed(objectSubscriber)
+      sender() ! ObjectSubscribed(rSub, replyTo, objectSubscriber)
   }
 
   private def persistEvent(persistentEvent: PersistentEvent): Unit =

--- a/really-core/src/main/scala/io/really/gorilla/ObjectSubscriber.scala
+++ b/really-core/src/main/scala/io/really/gorilla/ObjectSubscriber.scala
@@ -35,7 +35,7 @@ class ObjectSubscriber(rSubscription: RSubscription, globals: ReallyGlobals) ext
   val r = rSubscription.r
   private[gorilla] val logTag = s"ObjectSubscriber ${rSubscription.pushChannel.path}$$$r"
 
-  private[gorilla] var fields = rSubscription.fields.getOrElse(Set.empty)
+  private[gorilla] var fields = rSubscription.fields
 
   val shotgun = context.system.scheduler.scheduleOnce(globals.config.GorillaConfig.waitForReplayer, self, PoisonPill)
 

--- a/really-core/src/main/scala/io/really/gorilla/SubscribeAggregator.scala
+++ b/really-core/src/main/scala/io/really/gorilla/SubscribeAggregator.scala
@@ -8,25 +8,19 @@ import akka.actor.{ ActorLogging, ActorRef, Actor }
 import akka.contrib.pattern.Aggregator
 import io.really.R
 import io.really.RequestContext
-import io.really.WrappedSubscriptionRequest.WrappedSubscribe
+import io.really.ObjectSubscriptionRequest.SubscribeOnObject
 import io.really.gorilla.SubscriptionManager.{ SubscriptionDone, SubscribeOnR }
-import io.really.protocol.{ SubscriptionFailure, SubscriptionBody }
+import io.really.protocol.SubscriptionBody
 import scala.collection.mutable.ArrayBuffer
 import io.really.ReallyGlobals
 
-class SubscribeAggregator(subscriptionManager: ActorRef, globals: ReallyGlobals) extends Actor with Aggregator with ActorLogging {
+class SubscribeAggregator(request: SubscribeOnObject, delegate: ActorRef, subscriptionManager: ActorRef,
+    globals: ReallyGlobals) extends Actor with Aggregator with ActorLogging {
 
   import context._
   import SubscribeAggregator._
 
-  expectOnce {
-    case WrappedSubscribe(subscribeRequest, pushChannel) =>
-      new SubscribeAggregatorImpl(subscribeRequest.ctx, sender(), subscribeRequest.body, pushChannel)
-    case msg =>
-      log.error(s"Subscribe Aggregator got an unexpected response: $msg and going to die")
-      sender() ! UnsupportedResponse
-      context.stop(self)
-  }
+  new SubscribeAggregatorImpl(request.subscribeObject.ctx, delegate, request.subscribeObject.body, request.pushChannel)
 
   class SubscribeAggregatorImpl(ctx: RequestContext, requestDelegate: ActorRef, body: SubscriptionBody,
       pushChannel: ActorRef) {
@@ -37,13 +31,16 @@ class SubscribeAggregator(subscriptionManager: ActorRef, globals: ReallyGlobals)
     if (body.subscriptions.size > 0) {
       body.subscriptions.foreach {
         op =>
-          subscribeOnR(RSubscription(ctx, op.r, Some(op.fields), op.rev, requestDelegate, pushChannel))
+          subscribeOnR(RSubscription(ctx, op.r, op.fields, op.rev, requestDelegate, pushChannel))
       }
     } else {
       collectSubscriptions()
     }
 
-    context.system.scheduler.scheduleOnce(globals.config.GorillaConfig.waitForSubscriptionsAggregation, self, TimedOut)
+    val timer = context.system.scheduler.scheduleOnce(
+      globals.config.GorillaConfig.waitForSubscriptionsAggregation,
+      self, TimedOut
+    )
     expect {
       case TimedOut =>
         log.warning(s"Subscribe Aggregator timed out while waiting the subscriptions to be fulfilled for requester:" +
@@ -54,11 +51,8 @@ class SubscribeAggregator(subscriptionManager: ActorRef, globals: ReallyGlobals)
     def subscribeOnR(rSub: RSubscription) = {
       subscriptionManager ! SubscribeOnR(rSub)
       expectOnce {
-        case SubscriptionDone =>
-          results += rSub.r
-          processedCount += 1
-          collectSubscriptions()
-        case sf: SubscriptionFailure =>
+        case SubscriptionDone(r) =>
+          results += r
           processedCount += 1
           collectSubscriptions()
       }
@@ -66,6 +60,7 @@ class SubscribeAggregator(subscriptionManager: ActorRef, globals: ReallyGlobals)
 
     def collectSubscriptions(force: Boolean = false) {
       if (processedCount == body.subscriptions.size || force) {
+        timer.cancel()
         requestDelegate ! SubscribeAggregator.Subscribed(results.toSet)
         context.stop(self)
       }

--- a/really-core/src/main/scala/io/really/gorilla/SubscriptionManager.scala
+++ b/really-core/src/main/scala/io/really/gorilla/SubscriptionManager.scala
@@ -4,17 +4,12 @@
 
 package io.really.gorilla
 
-import akka.util.Timeout
-import io.really.protocol.SubscriptionFailure
 import scala.collection.mutable.Map
-import _root_.io.really.model.FieldKey
 import akka.actor._
+import _root_.io.really.model.FieldKey
+import _root_.io.really.protocol.SubscriptionFailure
 import _root_.io.really.{ R, ReallyGlobals }
-import _root_.io.really.WrappedSubscriptionRequest.{ WrappedSubscribe, WrappedUnsubscribe }
-import akka.pattern.{ AskTimeoutException, ask }
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.control.NonFatal
+import _root_.io.really.ObjectSubscriptionRequest.{ SubscribeOnObject, UnsubscribeFromObject }
 
 /**
  * SubscriptionManager is sharded actor and responsible for managing the subscriptions on objects, rooms and queries
@@ -45,43 +40,46 @@ class SubscriptionManager(globals: ReallyGlobals) extends Actor with ActorLoggin
 
   /**
    * Handles the messages of Objects subscriptions
-   * case `WrappedSubscribe` is expected to come externally as a request to subscribe on an object
-   * case `WrappedUnubscribe` is expected to come externally as a request to unsubscribe on an object
+   * case `SubscribeOnObject` is expected to come externally as a request to subscribe on an object
+   * case `UnsubscribeFromObject` is expected to come externally as a request to unsubscribe on an object
    * case `SubscribeOnR` is expected to come internally from the Subscribe request aggregator
    * case `UnubscribeFromR` is expected to come internally from the Unubscribe request aggregator
    */
   def objectSubscriptionsHandler: Receive = {
-    case request: WrappedSubscribe =>
-      context.actorOf(Props(new SubscribeAggregator(self, globals))) forward request
-    case request: WrappedUnsubscribe =>
+    case request: SubscribeOnObject =>
+      request.subscribeObject.body.subscriptions.length match {
+        case 1 =>
+          val subscriptionOp = request.subscribeObject.body.subscriptions.head
+          self ! SubscribeOnR(RSubscription(
+            request.subscribeObject.ctx,
+            subscriptionOp.r,
+            subscriptionOp.fields,
+            subscriptionOp.rev,
+            sender(),
+            request.pushChannel
+          ))
+        case len if len > 1 =>
+          context.actorOf(Props(new SubscribeAggregator(request, sender(), self, globals)))
+      }
+
+    case request: UnsubscribeFromObject =>
       ???
     case SubscribeOnR(subData) =>
+      val replyTo = sender()
       rSubscriptions.get(subData.pushChannel.path).map {
         rSub =>
-          rSub.objectSubscriber ! UpdateSubscriptionFields(subData.fields.getOrElse(Set.empty))
+          rSub.objectSubscriber ! UpdateSubscriptionFields(subData.fields)
       }.getOrElse {
-        implicit val timeout = Timeout(globals.config.GorillaConfig.waitForGorillaCenter)
-        val originalSender = sender()
-        val result = globals.gorillaEventCenter ? NewSubscription(subData)
-        result.onSuccess {
-          case ObjectSubscribed(objectSubscriber) =>
-            rSubscriptions += subData.pushChannel.path -> InternalRSubscription(objectSubscriber, subData.r)
-            context.watch(objectSubscriber) //TODO handle death
-            context.watch(subData.pushChannel) //TODO handle death
-            originalSender ! SubscriptionDone
-          case _ =>
-            val reason = s"Gorilla Center replied with unexpected response to new subscription request: $subData"
-            failedToRegisterNewSubscription(originalSender, subData.r, subData.pushChannel, reason)
-        }
-        result.onFailure {
-          case e: AskTimeoutException =>
-            val reason = s"SubscriptionManager timed out waiting for the Gorilla center response for" +
-              s" subscription $subData"
-            failedToRegisterNewSubscription(originalSender, subData.r, subData.pushChannel, reason)
-          case NonFatal(e) =>
-            val reason = s"Unexpected error while asking the Gorilla Center to establish a new subscription: $subData"
-            failedToRegisterNewSubscription(originalSender, subData.r, subData.pushChannel, reason)
-        }
+        globals.gorillaEventCenter ! NewSubscription(replyTo, subData)
+      }
+    case ObjectSubscribed(subData, replyTo, objectSubscriber) =>
+      rSubscriptions += subData.pushChannel.path -> InternalRSubscription(objectSubscriber, subData.r)
+      context.watch(objectSubscriber) //TODO handle death
+      context.watch(subData.pushChannel) //TODO handle death
+      if (replyTo == self) {
+        subData.requestDelegate ! SubscribeAggregator.Subscribed(Set(subData.r))
+      } else {
+        replyTo ! SubscriptionDone(subData.r)
       }
     case UnsubscribeFromR(subData) => //TODO Ack the delegate
       rSubscriptions.get(subData.pushChannel.path).map {
@@ -121,8 +119,8 @@ object SubscriptionManager {
 
   case object Unsubscribe
 
-  case class ObjectSubscribed(objectSubscriber: ActorRef)
+  case class ObjectSubscribed(subData: RSubscription, replyTo: ActorRef, objectSubscriber: ActorRef)
 
-  case object SubscriptionDone
+  case class SubscriptionDone(r: R)
 
 }

--- a/really-core/src/main/scala/io/really/gorilla/package.scala
+++ b/really-core/src/main/scala/io/really/gorilla/package.scala
@@ -14,7 +14,7 @@ package object gorilla {
   type SubscriptionID = String
   type PushEventType = String
 
-  case class RSubscription(ctx: RequestContext, r: R, fields: Option[Set[FieldKey]], rev: Revision,
+  case class RSubscription(ctx: RequestContext, r: R, fields: Set[FieldKey], rev: Revision,
     requestDelegate: ActorRef, pushChannel: ActorRef)
 
   case class RoomSubscription(ctx: RequestContext, r: R, requestDelegate: ActorRef,
@@ -22,7 +22,7 @@ package object gorilla {
 
   trait RoutableToGorillaCenter extends RoutableByR
 
-  case class NewSubscription(rSubscription: RSubscription) extends RoutableToGorillaCenter {
+  case class NewSubscription(replyTo: ActorRef, rSubscription: RSubscription) extends RoutableToGorillaCenter {
     val r = rSubscription.r
   }
 

--- a/really-core/src/main/scala/io/really/package.scala
+++ b/really-core/src/main/scala/io/really/package.scala
@@ -146,11 +146,12 @@ package io {
 
     }
 
-    object WrappedSubscriptionRequest {
+    //TODO rename the object
+    object ObjectSubscriptionRequest {
 
-      case class WrappedSubscribe(subscribeObject: Request.Subscribe, pushChannel: ActorRef) extends RoutableToSubscriptionManager
+      case class SubscribeOnObject(subscribeObject: Request.Subscribe, pushChannel: ActorRef) extends RoutableToSubscriptionManager
 
-      case class WrappedUnsubscribe(unsubscribeObject: Request.Unsubscribe, pushChannel: ActorRef) extends RoutableToSubscriptionManager
+      case class UnsubscribeFromObject(unsubscribeObject: Request.Unsubscribe, pushChannel: ActorRef) extends RoutableToSubscriptionManager
 
     }
 

--- a/really-core/src/test/scala/io/really/gorilla/ObjectSubscriberSpec.scala
+++ b/really-core/src/test/scala/io/really/gorilla/ObjectSubscriberSpec.scala
@@ -112,13 +112,13 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val pushChannel = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub1 = RSubscription(ctx, r, Some(Set("name")), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub1 = RSubscription(ctx, r, Set("name"), rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor1 = TestActorRef[TestObjectSubscriber](globals.objectSubscriberProps(rSub1))
     objectSubscriberActor1.underlyingActor.fields shouldEqual Set("name")
     objectSubscriberActor1.underlyingActor.r shouldEqual r
     objectSubscriberActor1.underlyingActor.logTag shouldEqual s"ObjectSubscriber ${pushChannel.ref.path}$$$r"
 
-    val rSub2 = RSubscription(ctx, r, Some(Set.empty), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub2 = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor2 = system.actorOf(globals.objectSubscriberProps(rSub2))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor2, rSub2, Some(rev))))
     objectSubscriberActor2 ! ReplayerSubscribed(replayer)
@@ -135,7 +135,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, Some(Set("name")), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set("name"), rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     deathProbe.watch(objectSubscriberActor)
     objectSubscriberActor ! SubscriptionManager.Unsubscribe
@@ -150,7 +150,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 602
-    val rSub = RSubscription(ctx, r, Some(Set.empty), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     deathProbe.watch(objectSubscriberActor)
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor, rSub, Some(rev))))
@@ -170,7 +170,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val pushChannel = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, Some(Set("name")), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set("name"), rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor, rSub, Some(rev))))
     objectSubscriberActor ! ReplayerSubscribed(replayer)
@@ -188,7 +188,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, Some(Set("name")), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set("name"), rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor, rSub, Some(rev))))
     objectSubscriberActor ! ReplayerSubscribed(replayer)
@@ -208,7 +208,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val pushChannel = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriber = system.actorOf(globals.objectSubscriberProps(rSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriber, rSub, Some(rev))))
     objectSubscriber ! ReplayerSubscribed(replayer)
@@ -224,7 +224,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     deathProbe.watch(objectSubscriberActor)
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor, rSub, Some(rev))))
@@ -241,7 +241,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val pushChannel = TestProbe()
     val rev: Revision = 1L
     val r = R / 'friend / 1
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val friendSub = rSub.copy(r = r)
     val objectSubscriber = system.actorOf(globals.objectSubscriberProps(friendSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriber, friendSub, Some(rev))))
@@ -260,7 +260,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val pushChannel = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'friend / 2
-    val friendSub = RSubscription(ctx, r, Some(Set("fName", "lName")), rev, requestDelegate.ref, pushChannel.ref)
+    val friendSub = RSubscription(ctx, r, Set("fName", "lName"), rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriber = system.actorOf(globals.objectSubscriberProps(friendSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriber, friendSub, Some(rev))))
     objectSubscriber ! ReplayerSubscribed(replayer)
@@ -280,8 +280,8 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val pushChannel = TestProbe()
     val rev: Revision = 1L
     val r = R / 'brand / 1
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
-    val brandSub = rSub.copy(r = r, fields = Some(Set("name", "since")))
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
+    val brandSub = rSub.copy(r = r, fields = Set("name", "since"))
     val objectSubscriber = system.actorOf(globals.objectSubscriberProps(brandSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriber, brandSub, Some(rev))))
     objectSubscriber ! ReplayerSubscribed(replayer)
@@ -299,7 +299,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     deathProbe.watch(objectSubscriberActor)
     EventFilter.error(occurrences = 1, message = s"ObjectSubscriber ${rSub.pushChannel.path}$$${r} is going to die since the subscription failed because of: Internal Server Error\n error code: 401") intercept {
@@ -315,7 +315,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor, rSub, Some(rev))))
     objectSubscriberActor ! ReplayerSubscribed(replayer)
@@ -333,7 +333,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val pushChannel = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'friend / 601
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor, rSub, Some(rev))))
     objectSubscriberActor ! ReplayerSubscribed(replayer)
@@ -383,7 +383,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor, rSub, Some(rev))))
     objectSubscriberActor ! ReplayerSubscribed(replayer)
@@ -402,7 +402,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriberActor, rSub, Some(rev))))
     objectSubscriberActor ! ReplayerSubscribed(replayer)
@@ -420,7 +420,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val deathProbe = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriberActor = system.actorOf(globals.objectSubscriberProps(rSub))
     deathProbe.watch(objectSubscriberActor)
     objectSubscriberActor ! "To stash message 1"
@@ -434,7 +434,7 @@ class ObjectSubscriberSpec(config: ReallyConfig) extends BaseActorSpecWithMongoD
     val pushChannel = TestProbe()
     val rev: Revision = 1L
     val r: R = R / 'users / 601
-    val rSub = RSubscription(ctx, r, Some(Set("notAField1", "notAField2")), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub = RSubscription(ctx, r, Set("notAField1", "notAField2"), rev, requestDelegate.ref, pushChannel.ref)
     val objectSubscriber = system.actorOf(globals.objectSubscriberProps(rSub))
     val replayer = system.actorOf(Props(new Replayer(globals, objectSubscriber, rSub, Some(rev))))
     objectSubscriber ! ReplayerSubscribed(replayer)

--- a/really-core/src/test/scala/io/really/gorilla/ReplayerSpec.scala
+++ b/really-core/src/test/scala/io/really/gorilla/ReplayerSpec.scala
@@ -84,7 +84,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
     val pushChannel = TestProbe().ref
     val rev = 23
     val r: R = R / 'users / 123
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
     val replayer = TestActorRef[Replayer](Props(new Replayer(globals, objectSubActor.ref, rSub, Some(rev))))
     replayer.underlyingActor.r should be(r)
     replayer.underlyingActor.min should be(rev)
@@ -114,7 +114,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
     val pushChannel = TestProbe().ref
     val rev: Revision = 2L
     val r: R = R / 'users / 124
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
     val probe = TestProbe()
     val obj = Json.obj("name" -> "Sara", "age" -> 20)
     val createdEvent = Created(r, obj, 1l, ctx)
@@ -163,7 +163,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
       val pushChannel = TestProbe().ref
       val rev: Revision = 3L
       val r: R = R / 'users / 125
-      val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+      val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
       val probe = TestProbe()
       val obj = Json.obj("name" -> "Sara", "age" -> 20)
       val createdEvent = Created(r, obj, 1l, ctx)
@@ -206,7 +206,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
       val pushChannel = TestProbe().ref
       val rev: Revision = 33L
       val r: R = R / 'users / 126
-      val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+      val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
       val probe = TestProbe()
       val obj = Json.obj("name" -> "Sara", "age" -> 20)
       val createdEvent = Created(r, obj, 1l, ctx)
@@ -247,7 +247,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
       val pushChannel = TestProbe().ref
       val rev: Revision = 10L
       val r: R = R / 'users / 127
-      val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+      val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
       val probe = TestProbe()
 
       val replayer = TestActorRef[Replayer](Props(new Replayer(globals, objectSubActor.ref, rSub, Some(5))))
@@ -269,7 +269,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
     val pushChannel = TestProbe().ref
     val rev: Revision = 2L
     val r: R = R / 'users / 128
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
     val probe = TestProbe()
 
     globals.collectionActor.tell(Create(ctx, r, Json.obj("name" -> "amal elshihaby", "age" -> 27)), probe.ref)
@@ -323,7 +323,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
       val pushChannel = TestProbe().ref
       val rev: Revision = 2L
       val r: R = R / 'users / 129
-      val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+      val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
       val probe = TestProbe()
 
       globals.collectionActor.tell(Create(ctx, r, Json.obj("name" -> "amal elshihaby", "age" -> 27)), probe.ref)
@@ -382,7 +382,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
     val pushChannel = TestProbe().ref
     val rev: Revision = 2L
     val r: R = R / 'users / 130
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
     val probe = TestProbe()
 
     val replayer = TestActorRef[Replayer](Props(new Replayer(globals, objectSubActor.ref, rSub, Some(5L))))
@@ -399,7 +399,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
     val pushChannel = TestProbe().ref
     val rev: Revision = 1L
     val r: R = R / 'users / 131
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
     val probe = TestProbe()
     val fullObj1 = Json.obj("_r" -> r.toString, "_rev" -> 1L, "name" -> "Sara", "age" -> 20)
     val createdEvent = Created(r, fullObj1, 1l, ctx)
@@ -450,7 +450,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
       val pushChannel = TestProbe().ref
       val rev: Revision = 2L
       val r: R = R / 'users / 132
-      val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+      val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
       val probe = TestProbe()
 
       globals.collectionActor.tell(Create(ctx, r, Json.obj("name" -> "amal elshihaby", "age" -> 27)), probe.ref)
@@ -492,7 +492,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
       val pushChannel = TestProbe().ref
       val rev: Revision = 2L
       val r: R = R / 'users / 99897
-      val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+      val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
       val probe = TestProbe()
 
       globals.collectionActor.tell(Create(ctx, r, Json.obj("name" -> "amal elshihaby", "age" -> 27)), probe.ref)
@@ -551,7 +551,7 @@ class ReplayerSpec(config: ReallyConfig) extends BaseActorSpecWithMongoDB(config
     val pushChannel = TestProbe().ref
     val rev: Revision = 69L
     val r: R = R / 'users / 134
-    val rSub = RSubscription(ctx, r, None, rev, requestDelegate, pushChannel)
+    val rSub = RSubscription(ctx, r, Set.empty, rev, requestDelegate, pushChannel)
     val probe = TestProbe()
 
     globals.collectionActor.tell(Create(ctx, r, Json.obj("name" -> "amal elshihaby", "age" -> 27)), probe.ref)

--- a/really-core/src/test/scala/io/really/gorilla/SubscriptionManagerSpec.scala
+++ b/really-core/src/test/scala/io/really/gorilla/SubscriptionManagerSpec.scala
@@ -32,7 +32,7 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
   val pushChannel = TestProbe()
   val rev: Revision = 1L
   val r: R = R / 'users / 1
-  val rSub = RSubscription(ctx, r, Some(Set("name")), rev, requestDelegate.ref, pushChannel.ref)
+  val rSub = RSubscription(ctx, r, Set("name"), rev, requestDelegate.ref, pushChannel.ref)
 
   val models: List[Model] = List(BaseActorSpec.userModel, BaseActorSpec.carModel,
     BaseActorSpec.companyModel, BaseActorSpec.authorModel, BaseActorSpec.postModel)
@@ -54,7 +54,7 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
       val subs = subscriptionManger.underlyingActor.rSubscriptions
       subs.isEmpty shouldBe true
       subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub), caller.ref)
-      caller.expectMsg(SubscriptionManager.SubscriptionDone)
+      caller.expectMsg(SubscriptionManager.SubscriptionDone(rSub.r))
       subs.size shouldBe 1
       val expectedRSub = subs.get(rSub.pushChannel.path).get
       expectedRSub.r shouldEqual rSub.r
@@ -68,7 +68,7 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
     val subs = subscriptionManger.underlyingActor.rSubscriptions
     subs.isEmpty shouldBe true
     subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub), caller.ref)
-    caller.expectMsg(SubscriptionManager.SubscriptionDone)
+    caller.expectMsg(SubscriptionManager.SubscriptionDone(rSub.r))
     val rCount = subs.size
     rCount shouldEqual 1
     subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub), caller.ref)
@@ -80,7 +80,7 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
     val subs = subscriptionManger.underlyingActor.rSubscriptions
     subs.isEmpty shouldBe true
     subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub), caller.ref)
-    caller.expectMsg(SubscriptionManager.SubscriptionDone)
+    caller.expectMsg(SubscriptionManager.SubscriptionDone(rSub.r))
     subscriptionManger.underlyingActor.rSubscriptions.isEmpty shouldBe false
     subscriptionManger.underlyingActor.rSubscriptions.size shouldBe 1
     val subscriptionActor = subscriptionManger.underlyingActor.rSubscriptions.toList(0)._2.objectSubscriber
@@ -91,13 +91,13 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
   }
 
   it should "handle Update subscription fields" in {
-    val rSub1 = RSubscription(ctx, r, Some(Set("name")), rev, requestDelegate.ref, pushChannel.ref)
-    val rSub2 = RSubscription(ctx, r, Some(Set("age", "name")), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub1 = RSubscription(ctx, r, Set("name"), rev, requestDelegate.ref, pushChannel.ref)
+    val rSub2 = RSubscription(ctx, r, Set("age", "name"), rev, requestDelegate.ref, pushChannel.ref)
     val subscriptionManger = TestActorRef[SubscriptionManager](globals.subscriptionManagerProps)
     val subs = subscriptionManger.underlyingActor.rSubscriptions
     subs.isEmpty shouldBe true
     subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub1), caller.ref)
-    caller.expectMsg(SubscriptionManager.SubscriptionDone)
+    caller.expectMsg(SubscriptionManager.SubscriptionDone(rSub.r))
     subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub2), caller.ref)
     subs.size.shouldEqual(1)
     val expectedRSub = subs.get(rSub1.pushChannel.path).get

--- a/really-core/src/test/scala/io/really/model/persistent/RequestRouterSpec.scala
+++ b/really-core/src/test/scala/io/really/model/persistent/RequestRouterSpec.scala
@@ -102,7 +102,7 @@ class RequestRouterSpec extends BaseActorSpec {
   }
 
   it should "forward message to subscription manager if command is Subscribe" in {
-    val req = WrappedSubscriptionRequest.WrappedSubscribe(
+    val req = ObjectSubscriptionRequest.SubscribeOnObject(
       Request.Subscribe(ctx, SubscriptionBody(List.empty)),
       TestProbe().ref
     )
@@ -111,7 +111,7 @@ class RequestRouterSpec extends BaseActorSpec {
   }
 
   it should "forward message to subscription manager if command is Unsubscribe" in {
-    val req = WrappedSubscriptionRequest.WrappedUnsubscribe(
+    val req = ObjectSubscriptionRequest.UnsubscribeFromObject(
       Request.Unsubscribe(ctx, UnsubscriptionBody(List.empty)),
       TestProbe().ref
     )


### PR DESCRIPTION
- Change the Ask pattern usage in the SubscriptionManager to Tell pattern
- If the Subscribe request contains only one object, the SubscriptionManager should handle itself
- Fix the SubscriptionAggregator random failure