### PR TITLE
RIO-96 bug(Subscription Manager): Subscription is singleton is fixed to to be per user per resource

### DIFF
--- a/modules/really-core/src/main/scala/io/really/gorilla/SubscribeAggregator.scala
+++ b/modules/really-core/src/main/scala/io/really/gorilla/SubscribeAggregator.scala
@@ -8,13 +8,13 @@ import akka.actor.{ ActorLogging, ActorRef, Actor }
 import akka.contrib.pattern.Aggregator
 import io.really.R
 import io.really.RequestContext
-import io.really.Request.SubscribeOnObject
+import io.really.Request.SubscribeOnObjects
 import io.really.gorilla.SubscriptionManager.{ SubscriptionDone, SubscribeOnR }
 import io.really.protocol.SubscriptionBody
 import scala.collection.mutable.ArrayBuffer
 import io.really.ReallyGlobals
 
-class SubscribeAggregator(request: SubscribeOnObject, delegate: ActorRef, subscriptionManager: ActorRef,
+class SubscribeAggregator(request: SubscribeOnObjects, delegate: ActorRef, subscriptionManager: ActorRef,
     globals: ReallyGlobals) extends Actor with Aggregator with ActorLogging {
 
   import context._

--- a/modules/really-core/src/main/scala/io/really/package.scala
+++ b/modules/really-core/src/main/scala/io/really/package.scala
@@ -120,9 +120,9 @@ package io {
 
     object Request {
 
-      case class SubscribeOnObject(ctx: RequestContext, body: SubscriptionBody, pushChannel: ActorRef) extends Request with RoutableToSubscriptionManager
+      case class SubscribeOnObjects(ctx: RequestContext, body: SubscriptionBody, pushChannel: ActorRef) extends Request with RoutableToSubscriptionManager
 
-      case class UnsubscribeFromObject(ctx: RequestContext, body: UnsubscriptionBody, pushChannel: ActorRef) extends Request with RoutableToSubscriptionManager
+      case class UnsubscribeFromObjects(ctx: RequestContext, body: UnsubscriptionBody, pushChannel: ActorRef) extends Request with RoutableToSubscriptionManager
 
       case class GetSubscription(ctx: RequestContext, r: R) extends Request with RoutableByR with RoutableToSubscriptionManager
 

--- a/modules/really-core/src/main/scala/io/really/protocol/ProtocolJsonHelper.scala
+++ b/modules/really-core/src/main/scala/io/really/protocol/ProtocolJsonHelper.scala
@@ -9,7 +9,6 @@ import io.really._
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
-import play.api.libs.json.util._
 import play.api.libs.json.Writes._
 
 /*
@@ -45,7 +44,7 @@ object ProtocolFormats {
     object Subscribe {
       val bodyReads = (__ \ 'body).read[SubscriptionBody]
 
-      def read(ctx: RequestContext, replyTo: ActorRef) = (bodyReads) map (body => Request.SubscribeOnObject(ctx, body, replyTo))
+      def read(ctx: RequestContext, replyTo: ActorRef) = (bodyReads) map (body => Request.SubscribeOnObjects(ctx, body, replyTo))
     }
 
     /*
@@ -54,7 +53,7 @@ object ProtocolFormats {
     object Unsubscribe {
       val bodyReads = (__ \ 'body).read[UnsubscriptionBody]
 
-      def read(ctx: RequestContext, replyTo: ActorRef) = (bodyReads) map (body => Request.UnsubscribeFromObject(ctx, body, replyTo))
+      def read(ctx: RequestContext, replyTo: ActorRef) = (bodyReads) map (body => Request.UnsubscribeFromObjects(ctx, body, replyTo))
     }
 
     /*

--- a/modules/really-core/src/main/scala/io/really/protocol/package.scala
+++ b/modules/really-core/src/main/scala/io/really/protocol/package.scala
@@ -147,22 +147,9 @@ package object protocol {
   }
 
   /*
-   * Represents unsubscription operation for one object on unsubscribe request
-   */
-  case class UnsubscriptionOp(r: R, fields: Set[String] = Set.empty)
-
-  //TODO change fields type
-  /*
-   * Represent implicit JSON Format for SubscriptionOp
-   */
-  object UnsubscriptionOp {
-    implicit val fmt = Json.format[UnsubscriptionOp]
-  }
-
-  /*
    * Represent body request for unsubscribe request
    */
-  case class UnsubscriptionBody(subscriptions: List[UnsubscriptionOp])
+  case class UnsubscriptionBody(subscriptions: List[R])
 
   /*
    * Represent implicit JSON Format for SubscriptionBody

--- a/modules/really-core/src/test/scala/io/really/gorilla/SubscribeAggregatorSpec.scala
+++ b/modules/really-core/src/test/scala/io/really/gorilla/SubscribeAggregatorSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.Props
 import akka.testkit.{ EventFilter, TestProbe, TestActorRef }
 import com.typesafe.config.ConfigFactory
 import io.really._
-import _root_.io.really.Request.SubscribeOnObject
+import _root_.io.really.Request.SubscribeOnObjects
 import _root_.io.really.gorilla.SubscribeAggregator.{ Subscribed, UnsupportedResponse }
 import _root_.io.really.gorilla.SubscriptionManager.{ SubscriptionDone, SubscribeOnR }
 import _root_.io.really.protocol.{ SubscriptionFailure, SubscriptionBody, SubscriptionOp }
@@ -34,7 +34,7 @@ class SubscribeAggregatorSpec(config: ReallyConfig) extends BaseActorSpec(config
     val pushChannel = TestProbe()
     val delegate = TestProbe()
     val body = SubscriptionBody(List(SubscriptionOp(r1, 1)))
-    val rSub = SubscribeOnObject(ctx, body, pushChannel.ref)
+    val rSub = SubscribeOnObjects(ctx, body, pushChannel.ref)
     val aggregator = TestActorRef[SubscribeAggregator](Props(new SubscribeAggregator(rSub, delegate.ref, manager,
       globals)))
     probe.watch(aggregator)
@@ -48,7 +48,7 @@ class SubscribeAggregatorSpec(config: ReallyConfig) extends BaseActorSpec(config
     val delegate = TestProbe()
     val body = SubscriptionBody(List(SubscriptionOp(r1, 1), SubscriptionOp(r2, 1), SubscriptionOp(r3, 1),
       SubscriptionOp(r4, 1), SubscriptionOp(r5, 1)))
-    val rSub = SubscribeOnObject(ctx, body, pushChannel.ref)
+    val rSub = SubscribeOnObjects(ctx, body, pushChannel.ref)
     TestActorRef[SubscribeAggregator](Props(new SubscribeAggregator(rSub, delegate.ref, manager,
       globals)))
     delegate.expectMsg(Subscribed(Set(r2, r4)))
@@ -60,7 +60,7 @@ class SubscribeAggregatorSpec(config: ReallyConfig) extends BaseActorSpec(config
     val delegate = TestProbe()
     val body = SubscriptionBody(List(SubscriptionOp(r1, 1), SubscriptionOp(r2, 1), SubscriptionOp(r3, 1),
       SubscriptionOp(r4, 1), SubscriptionOp(r5, 1)))
-    val rSub = SubscribeOnObject(ctx, body, pushChannel.ref)
+    val rSub = SubscribeOnObjects(ctx, body, pushChannel.ref)
     TestActorRef[SubscribeAggregator](Props(new SubscribeAggregator(rSub, delegate.ref, manager, globals)))
     delegate.expectMsg(Subscribed(Set.empty))
   }
@@ -71,7 +71,7 @@ class SubscribeAggregatorSpec(config: ReallyConfig) extends BaseActorSpec(config
     val delegate = TestProbe()
     val body = SubscriptionBody(List(SubscriptionOp(r1, 1), SubscriptionOp(r2, 1), SubscriptionOp(r3, 1),
       SubscriptionOp(r4, 1), SubscriptionOp(r5, 1)))
-    val rSub = SubscribeOnObject(ctx, body, pushChannel.ref)
+    val rSub = SubscribeOnObjects(ctx, body, pushChannel.ref)
     EventFilter.warning(
       message = s"Subscribe Aggregator timed out while waiting the subscriptions to be fulfilled for requester:" +
       s" ${delegate.ref}",

--- a/modules/really-core/src/test/scala/io/really/gorilla/SubscriptionManagerSpec.scala
+++ b/modules/really-core/src/test/scala/io/really/gorilla/SubscriptionManagerSpec.scala
@@ -4,16 +4,18 @@
 
 package io.really.gorilla
 
-import akka.actor.{ ActorRef, Props }
-import akka.testkit.{ TestProbe, TestActorRef }
-import akka.persistence.{ Update => PersistenceUpdate }
+import akka.actor.{ActorRef, Props}
+import akka.testkit.{TestProbe, TestActorRef}
+import akka.persistence.{Update => PersistenceUpdate}
 import io.really._
-import _root_.io.really.model.{ Model, FieldKey }
-import _root_.io.really.model.persistent.ModelRegistry.{ RequestModel, ModelResult }
+import _root_.io.really.model.{Model, FieldKey}
+import _root_.io.really.model.persistent.ModelRegistry.{RequestModel, ModelResult}
 import _root_.io.really.model.persistent.PersistentModelStore
 import _root_.io.really.fixture.PersistentModelStoreFixture
 import _root_.io.really.gorilla.mock.TestObjectSubscriber
 import _root_.io.really.gorilla.mock.TestObjectSubscriber._
+import _root_.io.really.protocol.{SubscriptionBody, SubscriptionOp}
+import _root_.io.really.gorilla.SubscribeAggregator.Subscribed
 
 class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
 
@@ -23,7 +25,7 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
       Props(classOf[TestObjectSubscriber], rSubscription, this)
 
     override def replayerProps(rSubscription: RSubscription, objectSubscriber: ActorRef,
-      maxMarker: Option[Revision]): Props = Props.empty
+                               maxMarker: Option[Revision]): Props = Props.empty
   }
 
   val caller = TestProbe()
@@ -50,18 +52,18 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
 
   "Subscription Manager" should "handle SubscribeOnR, create an ObjectSubscriptionActor and update the internal" +
     " state" in {
-      val subscriptionManger = TestActorRef[SubscriptionManager](globals.subscriptionManagerProps)
-      val subs = subscriptionManger.underlyingActor.rSubscriptions
-      subs.isEmpty shouldBe true
-      subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub), caller.ref)
-      caller.expectMsg(SubscriptionManager.SubscriptionDone(rSub.r))
-      subs.size shouldBe 1
-      val expectedRSub = subs.get(rSub.pushChannel.path).get
-      expectedRSub.r shouldEqual rSub.r
-      expectedRSub.objectSubscriber.tell(GetFieldList, caller.ref)
-      val msg = caller.expectMsgType[Set[FieldKey]]
-      msg shouldEqual Set("name")
-    }
+    val subscriptionManger = TestActorRef[SubscriptionManager](globals.subscriptionManagerProps)
+    val subs = subscriptionManger.underlyingActor.rSubscriptions
+    subs.isEmpty shouldBe true
+    subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub), caller.ref)
+    caller.expectMsg(SubscriptionManager.SubscriptionDone(rSub.r))
+    subs.size shouldBe 1
+    val expectedRSub = subs.get((rSub.pushChannel.path, r)).get
+    expectedRSub.r shouldEqual rSub.r
+    expectedRSub.objectSubscriber.tell(GetFieldList, caller.ref)
+    val msg = caller.expectMsgType[Set[FieldKey]]
+    msg shouldEqual Set("name")
+  }
 
   it should "doesn't add same caller twice to subscriptionList" in {
     val subscriptionManger = TestActorRef[SubscriptionManager](globals.subscriptionManagerProps)
@@ -75,7 +77,65 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
     subs.size.shouldEqual(rCount)
   }
 
-  it should "handle UnsubscribeOnR, send it to the ObjectSubscriptionActor and remove it from the internal state" in {
+  it should "handle SubscribeOnObjects correctly for multiple Rs subscription" in {
+    val subscriptionManger = TestActorRef[SubscriptionManager](globals.subscriptionManagerProps)
+    val subs = subscriptionManger.underlyingActor.rSubscriptions
+    subs.isEmpty shouldBe true
+    val r1 = R / 'users / 1
+    val r2 = R / 'users / 2
+    val r3 = R / 'users / 3
+    val r4 = R / 'users / 4
+    val r5 = r4
+    val sub1 = SubscriptionOp(r1, 1L)
+    val sub2 = SubscriptionOp(r2, 1L)
+    val sub3 = SubscriptionOp(r3, 1L)
+    val sub4 = SubscriptionOp(r4, 1L)
+    val sub5 = SubscriptionOp(r5, 1L)
+    subscriptionManger.tell(Request.SubscribeOnObjects(ctx, SubscriptionBody(List(sub1, sub2, sub3, sub4, sub5)),
+      pushChannel.ref), caller.ref)
+    caller.expectMsg(Subscribed(Set(r1, r2, r3, r4, r5)))
+    subs.size shouldBe 4
+    subs.get((pushChannel.ref.path, r1)).get.r shouldBe r1
+    subs.get((pushChannel.ref.path, r2)).get.r shouldBe r2
+    subs.get((pushChannel.ref.path, r3)).get.r shouldBe r3
+    subs.get((pushChannel.ref.path, r4)).get.r shouldBe r4
+  }
+
+  it should "allow multiple users to subscribe to a specific resource" in {
+    val subscriptionManger = TestActorRef[SubscriptionManager](globals.subscriptionManagerProps)
+    val subs = subscriptionManger.underlyingActor.rSubscriptions
+    subs.isEmpty shouldBe true
+    val r = R / 'users / 1
+    val pushChannel1 = TestProbe()
+    val pushChannel2 = TestProbe()
+    val pushChannel3 = TestProbe()
+    val pushChannel4 = TestProbe()
+
+    val sub = SubscriptionOp(r, 1L)
+    subscriptionManger.tell(Request.SubscribeOnObjects(ctx, SubscriptionBody(List(sub)),
+      pushChannel1.ref), pushChannel1.ref)
+    pushChannel1.expectMsg(Subscribed(Set(r)))
+
+    subscriptionManger.tell(Request.SubscribeOnObjects(ctx, SubscriptionBody(List(sub)),
+      pushChannel2.ref), pushChannel2.ref)
+    pushChannel2.expectMsg(Subscribed(Set(r)))
+
+    subscriptionManger.tell(Request.SubscribeOnObjects(ctx, SubscriptionBody(List(sub)),
+      pushChannel3.ref), pushChannel3.ref)
+    pushChannel3.expectMsg(Subscribed(Set(r)))
+
+    subscriptionManger.tell(Request.SubscribeOnObjects(ctx, SubscriptionBody(List(sub)),
+      pushChannel4.ref), pushChannel4.ref)
+    pushChannel4.expectMsg(Subscribed(Set(r)))
+
+    subs.size shouldBe 4
+    subs.get((pushChannel1.ref.path, r)).get.r shouldBe r
+    subs.get((pushChannel2.ref.path, r)).get.r shouldBe r
+    subs.get((pushChannel3.ref.path, r)).get.r shouldBe r
+    subs.get((pushChannel4.ref.path, r)).get.r shouldBe r
+  }
+
+  it should "handle UnsubscribeFromR, send it to the ObjectSubscriptionActor and remove it from the internal state" in {
     val subscriptionManger = TestActorRef[SubscriptionManager](globals.subscriptionManagerProps)
     val subs = subscriptionManger.underlyingActor.rSubscriptions
     subs.isEmpty shouldBe true
@@ -100,10 +160,11 @@ class SubscriptionManagerSpec extends BaseActorSpecWithMongoDB {
     caller.expectMsg(SubscriptionManager.SubscriptionDone(rSub.r))
     subscriptionManger.tell(SubscriptionManager.SubscribeOnR(rSub2), caller.ref)
     subs.size.shouldEqual(1)
-    val expectedRSub = subs.get(rSub1.pushChannel.path).get
+    val expectedRSub = subs.get((rSub1.pushChannel.path, r)).get
     expectedRSub.r shouldEqual rSub1.r
     expectedRSub.objectSubscriber.tell(GetFieldList, caller.ref)
     val msg = caller.expectMsgType[Set[FieldKey]]
     msg shouldEqual Set("name", "age")
   }
+
 }

--- a/modules/really-core/src/test/scala/io/really/model/persistent/RequestRouterSpec.scala
+++ b/modules/really-core/src/test/scala/io/really/model/persistent/RequestRouterSpec.scala
@@ -104,7 +104,7 @@ class RequestRouterSpec extends BaseActorSpec {
   }
 
   it should "forward message to subscription manager if command is Subscribe" in {
-    val req = Request.SubscribeOnObject(
+    val req = Request.SubscribeOnObjects(
       ctx, SubscriptionBody(List.empty),
       TestProbe().ref
     )
@@ -113,7 +113,7 @@ class RequestRouterSpec extends BaseActorSpec {
   }
 
   it should "forward message to subscription manager if command is Unsubscribe" in {
-    val req = Request.UnsubscribeFromObject(
+    val req = Request.UnsubscribeFromObjects(
       ctx, UnsubscriptionBody(List.empty),
       TestProbe().ref
     )

--- a/modules/really-core/src/test/scala/io/really/protocol/RequestReadsSpec.scala
+++ b/modules/really-core/src/test/scala/io/really/protocol/RequestReadsSpec.scala
@@ -6,8 +6,6 @@ package io.really.protocol
 import akka.testkit.TestProbe
 import io.really.rql.RQL.Query.QueryReads
 import io.really.rql.RQLTokens.PaginationToken
-import org.joda.time.DateTime
-import org.scalatest.{ Matchers, FlatSpec }
 import play.api.libs.json._
 import io.really._
 
@@ -29,7 +27,7 @@ class RequestReadsSpec extends BaseActorSpec {
 
     val result = req.validate(ProtocolFormats.RequestReads.Subscribe.read(ctx, replyTo))
 
-    assertResult(Request.SubscribeOnObject(
+    assertResult(Request.SubscribeOnObjects(
       ctx,
       SubscriptionBody(
         List(
@@ -91,20 +89,20 @@ class RequestReadsSpec extends BaseActorSpec {
       "cmd" -> "unsubscribe",
       "body" -> Json.obj(
         "subscriptions" -> List(
-          Json.obj("r" -> "/users/12131231232/", "fields" -> Set("name", "age")),
-          Json.obj("r" -> "/users/121312787632/", "fields" -> Set.empty[String])
+          R("/users/12131231232/"),
+          R("/users/121312787632/")
         )
       )
     )
 
     val result = req.validate(ProtocolFormats.RequestReads.Unsubscribe.read(ctx, replyTo))
 
-    assertResult(Request.UnsubscribeFromObject(
+    assertResult(Request.UnsubscribeFromObjects(
       ctx,
       UnsubscriptionBody(
         List(
-          UnsubscriptionOp(R("/users/12131231232/"), Set("name", "age")),
-          UnsubscriptionOp(R("/users/121312787632/"), Set.empty)
+          R("/users/12131231232/"),
+          R("/users/121312787632/")
         )
       ),
       replyTo


### PR DESCRIPTION
- Subscription is singleton is fixed to to be per user per resource
- Removed the fields from Unsubscribe
- Some case classes renaming